### PR TITLE
Level up use vanilla exp (switchable)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ dependencies {
 	}
 
     // Cardinal-Components-API
-    modApi "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cardinal_components}"
-    modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-scoreboard:${project.cardinal_components}"
+    modApi  include("io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cardinal_components}")
+    modImplementation include("io.github.onyxstudios.Cardinal-Components-API:cardinal-components-scoreboard:${project.cardinal_components}")
     //modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cardinal_components}"
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
+    // Cardinal-Components-API
+    modApi "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cardinal_components}"
+    modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-scoreboard:${project.cardinal_components}"
+    //modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cardinal_components}"
+
 
     //de/siphalor/spiceoffabric-1.17/1.4.1+1.17.1/spiceoffabric-1.17-1.4.1+1.17.1.pom
     //de/siphalor/spiceoffabric-1.17/1.4.1+1.17.1/spiceoffabric-1.17-1.4.1+1.17.1.pom

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.11
 
 # Mod Properties
-    mod_version=1.1.2
+    mod_version=1.2.0
     maven_group=net.levelz
     archives_base_name=levelz
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@ org.gradle.jvmargs=-Xmx1G
 	mod_menu_version=3.0.0
     cottonmc_version=5.0.0-beta.2+1.18-rc1
     wthit_version=4.1.2
+
+# Cardinal-Components-API
+cardinal_components=4.0.1

--- a/src/main/java/net/levelz/config/LevelRule.java
+++ b/src/main/java/net/levelz/config/LevelRule.java
@@ -1,0 +1,134 @@
+package net.levelz.config;
+
+import com.mojang.brigadier.arguments.*;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import dev.onyxstudios.cca.api.v3.component.Component;
+import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
+import net.levelz.init.ConfigInit;
+import net.levelz.init.LevelZComponent;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+public class LevelRule implements Component, AutoSyncedComponent {
+    private static final String CONFIGURED = "configured";
+    private static LevelRule instance;
+    private static Scoreboard scoreboard;
+    //private Integer maxLevel;
+    private Boolean useVanillaExp;
+
+    public static void registry(ServerScoreboard provider) {
+        if (LevelRule.scoreboard == null)
+            LevelRule.scoreboard = provider;
+        instance = LevelZComponent.getLevelRule(scoreboard);
+        if (instance.useVanillaExp() == null)
+            instance.useVanillaExp = ConfigInit.CONFIG.useVanillaExp;
+    }
+
+    public static LevelRule getInstance() {
+        return instance;
+    }
+
+    public Boolean useVanillaExp() {
+        return useVanillaExp;
+    }
+
+    @Override
+    public void readFromNbt(NbtCompound tag) {
+        String configured = tag.getString(CONFIGURED);
+        for (Field field : LevelRule.class.getDeclaredFields()) {
+            String fieldName = field.getName();
+            if (!configured.contains(fieldName)) continue;
+            try {
+                this.setValue(fieldName, switch (field.getType().getSimpleName()) {
+                    case "Integer", "int" -> tag.getInt(fieldName);
+                    case "Long", "long" -> tag.getLong(fieldName);
+                    case "Float", "float" -> tag.getFloat(fieldName);
+                    case "Double", "double" -> tag.getDouble(fieldName);
+                    case "Boolean", "boolean" -> tag.getBoolean(fieldName);
+                    case "String" -> tag.getString(fieldName);
+                    default -> throw new IllegalArgumentException();
+                });
+            } catch (IllegalAccessException | NoSuchFieldException ignored) {
+            }
+        }
+    }
+
+    @Override
+    public void writeToNbt(NbtCompound tag) {
+        Set<String> configured = new HashSet<>();
+        for (Field field : LevelRule.class.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers())) continue;
+            try {
+                String fieldName = field.getName();
+                Object value = field.get(this);
+                if (value == null) continue;
+                switch (field.getType().getSimpleName()) {
+                    case "Integer", "int" -> tag.putInt(fieldName, (Integer) value);
+                    case "Long", "long" -> tag.putLong(fieldName, (Long) value);
+                    case "Float", "float" -> tag.putFloat(fieldName, (Float) value);
+                    case "Double", "double" -> tag.putDouble(fieldName, (Double) value);
+                    case "Boolean", "boolean" -> tag.putBoolean(fieldName, (Boolean) value);
+                    case "String" -> tag.putString(fieldName, (String) value);
+                }
+                configured.add(fieldName);
+            } catch (IllegalAccessException ignored) {
+            }
+        }
+        tag.putString(CONFIGURED, String.join(",", configured));
+    }
+
+    public static LiteralArgumentBuilder<ServerCommandSource> commandBuilder(String literal, int permissionLevel) {
+        LiteralArgumentBuilder<ServerCommandSource> builder = CommandManager.literal(literal).requires(serverCommandSource -> serverCommandSource.hasPermissionLevel(permissionLevel));
+        for (Field field : LevelRule.class.getDeclaredFields()) {
+            if (Modifier.isStatic(field.getModifiers())) continue;
+            builder.then(CommandManager.literal(field.getName()).then(
+                    switch (field.getType().getSimpleName()) {
+                        case "Integer", "int" -> CommandManager.argument(field.getName(), IntegerArgumentType.integer(0))
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), IntegerArgumentType.getInteger(context, field.getName())));
+                        case "Long", "long" -> CommandManager.argument(field.getName(), LongArgumentType.longArg(0))
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), IntegerArgumentType.getInteger(context, field.getName())));
+                        case "Float", "float" -> CommandManager.argument(field.getName(), FloatArgumentType.floatArg(0))
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), FloatArgumentType.getFloat(context, field.getName())));
+                        case "Double", "double" -> CommandManager.argument(field.getName(), DoubleArgumentType.doubleArg(0))
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), DoubleArgumentType.getDouble(context, field.getName())));
+                        case "Boolean", "boolean" -> CommandManager.argument(field.getName(), BoolArgumentType.bool())
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), BoolArgumentType.getBool(context, field.getName())));
+                        default -> CommandManager.argument(field.getName(), StringArgumentType.string())
+                                .executes(context -> executeRuleCommand(context.getSource(), field.getName(), StringArgumentType.getString(context, field.getName())));
+                    })
+            );
+        }
+        return builder;
+    }
+
+    private static int executeRuleCommand(ServerCommandSource source, String rule, Object value) {
+        Text feedback = null;
+        try {
+            instance.setValue(rule, value);
+            feedback = new TranslatableText("commands.levelz.rule.changed");
+        } catch (IllegalAccessException e) {
+            feedback = new TranslatableText("commands.levelz.rule.error");
+        } catch (NoSuchFieldException e) {
+            feedback = new TranslatableText("commands.levelz.rule.notfound");
+        } finally {
+            source.sendFeedback(feedback, true);
+        }
+        return 0;
+    }
+
+    public void setValue(String field, Object value) throws NoSuchFieldException, IllegalAccessException {
+        Field f = LevelRule.class.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(this, value);
+    }
+}

--- a/src/main/java/net/levelz/config/LevelzConfig.java
+++ b/src/main/java/net/levelz/config/LevelzConfig.java
@@ -11,6 +11,9 @@ public class LevelzConfig implements ConfigData {
     @ConfigEntry.Category("level_setting")
     public int maxLevel = 20;
     @ConfigEntry.Category("level_setting")
+    @ConfigEntry.Gui.Tooltip
+    public boolean useVanillaExp = true;
+    @ConfigEntry.Category("level_setting")
     @Comment("Applies if bonus chest world setting is enabled")
     public int startPoints = 5;
     @ConfigEntry.Category("level_setting")

--- a/src/main/java/net/levelz/config/LevelzConfig.java
+++ b/src/main/java/net/levelz/config/LevelzConfig.java
@@ -11,7 +11,7 @@ public class LevelzConfig implements ConfigData {
     @ConfigEntry.Category("level_setting")
     public int maxLevel = 20;
     @ConfigEntry.Category("level_setting")
-    @ConfigEntry.Gui.Tooltip
+    @ConfigEntry.Gui.Tooltip(count = 3)
     public boolean useVanillaExp = true;
     @ConfigEntry.Category("level_setting")
     @Comment("Applies if bonus chest world setting is enabled")
@@ -96,5 +96,4 @@ public class LevelzConfig implements ConfigData {
     @ConfigEntry.Category("level_setting")
     @Comment("Highlight locked blocks in red.")
     public boolean highlightLocked = false;
-
 }

--- a/src/main/java/net/levelz/gui/LevelzGui.java
+++ b/src/main/java/net/levelz/gui/LevelzGui.java
@@ -67,9 +67,20 @@ public class LevelzGui extends LightweightGuiDescription {
         WDynamicLabel fortuneLabel = new WDynamicLabel(() -> "" + BigDecimal.valueOf(playerEntity.getAttributeValue(EntityAttributes.GENERIC_LUCK)).setScale(2, RoundingMode.HALF_DOWN).floatValue());
         WDynamicLabel overallLevel = new WDynamicLabel(() -> String.format(Language.getInstance().get("text.levelz.gui.level"), playerStatsManager.getLevel("level")));
         WDynamicLabel skillPoints = new WDynamicLabel(() -> String.format(Language.getInstance().get("text.levelz.gui.points"), playerStatsManager.getLevel("points")));
-        WDynamicLabel nextLevel = new WDynamicLabel(
-                () -> "XP " + (int) (playerStatsManager.levelProgress * playerStatsManager.getNextLevelExperience()) + " / " + playerStatsManager.getNextLevelExperience());
-
+        WDynamicLabel nextLevel;
+        if (ConfigInit.CONFIG.useVanillaExp) {
+            nextLevel = new WDynamicLabel(() -> String.format("XP %d / %d", PlayerStatsManager.getPlayerExp(playerEntity), playerStatsManager.getNextLevelExperience()));
+            ZWButton levelUp = new ZWButton(new TranslatableText("text.levelz.gui.level_up"), 10);
+            levelUp.setEnabled(playerStatsManager.getLevelProgress(playerEntity) >= 1 && !playerStatsManager.isMaxLevel());
+            levelUp.setOnClick(() -> {
+                PlayerStatsClientPacket.writeC2SLevelUpPacket();
+                levelUp.setEnabled(playerStatsManager.getLevelProgress(playerEntity) >= 1 && !playerStatsManager.isMaxLevel());
+            });
+            root.add(levelUp, 110, 49);
+        } else {
+            nextLevel = new WDynamicLabel(
+                    () -> "XP " + (int) (playerStatsManager.levelProgress * playerStatsManager.getNextLevelExperience()) + " / " + playerStatsManager.getNextLevelExperience());
+        }
         root.add(lifeLabel, 74, 22);
         root.add(protectionLabel, 74, 36);
         root.add(damageLabel, 124, 22);

--- a/src/main/java/net/levelz/gui/LevelzGui.java
+++ b/src/main/java/net/levelz/gui/LevelzGui.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.levelz.access.PlayerStatsManagerAccess;
+import net.levelz.config.LevelRule;
 import net.levelz.data.LevelLists;
 import net.levelz.init.ConfigInit;
 import net.levelz.network.PlayerStatsClientPacket;
@@ -68,7 +69,7 @@ public class LevelzGui extends LightweightGuiDescription {
         WDynamicLabel overallLevel = new WDynamicLabel(() -> String.format(Language.getInstance().get("text.levelz.gui.level"), playerStatsManager.getLevel("level")));
         WDynamicLabel skillPoints = new WDynamicLabel(() -> String.format(Language.getInstance().get("text.levelz.gui.points"), playerStatsManager.getLevel("points")));
         WDynamicLabel nextLevel;
-        if (ConfigInit.CONFIG.useVanillaExp) {
+        if (LevelRule.getInstance().useVanillaExp()) {
             nextLevel = new WDynamicLabel(() -> String.format("XP %d / %d", PlayerStatsManager.getPlayerExp(playerEntity), playerStatsManager.getNextLevelExperience()));
             ZWButton levelUp = new ZWButton(new TranslatableText("text.levelz.gui.level_up"), 10);
             levelUp.setEnabled(playerStatsManager.getLevelProgress(playerEntity) >= 1 && !playerStatsManager.isMaxLevel());

--- a/src/main/java/net/levelz/gui/LevelzScreen.java
+++ b/src/main/java/net/levelz/gui/LevelzScreen.java
@@ -35,7 +35,7 @@ public class LevelzScreen extends CottonClientScreen {
             RenderSystem.enableDepthTest();
             RenderSystem.setShaderTexture(0, DrawableHelper.GUI_ICONS_TEXTURE);
             PlayerStatsManager playerStatsManager = ((PlayerStatsManagerAccess) this.client.player).getPlayerStatsManager(this.client.player);
-            int m = (int) (playerStatsManager.levelProgress * 131.0F);
+            int m = (int) (playerStatsManager.getLevelProgress(this.client.player) * 129.0F);
             int x = scaledWidth / 2 - 41;
             int n = scaledHeight / 2 - 45;
             LevelzScreen.drawTexture(matrices, x, n, 130, 5, 0F, 64F, 182, 5, 256, 256);

--- a/src/main/java/net/levelz/gui/ZWButton.java
+++ b/src/main/java/net/levelz/gui/ZWButton.java
@@ -1,15 +1,30 @@
 package net.levelz.gui;
 
+import io.github.cottonmc.cotton.gui.widget.TooltipBuilder;
 import io.github.cottonmc.cotton.gui.widget.WButton;
 import io.github.cottonmc.cotton.gui.widget.icon.Icon;
 import io.github.cottonmc.cotton.gui.widget.icon.TextureIcon;
-import net.fabricmc.api.Environment;
 import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 @Environment(EnvType.CLIENT)
 public class ZWButton extends WButton {
+
+    private int iconSize = 13;
+
+    public ZWButton() {
+        super();
+    }
+
+    public ZWButton(Text text, int size) {
+        super(text);
+        this.width = size;
+        this.height = size;
+        this.iconSize = size;
+    }
 
     @Override
     public void paint(MatrixStack matrices, int x, int y, int mouseX, int mouseY) {
@@ -23,13 +38,19 @@ public class ZWButton extends WButton {
         } else {
             icon = new TextureIcon(new Identifier("levelz:textures/gui/disabled_plus_icon.png"));
         }
-        icon.paint(matrices, x + 1, y + 1, 13);
+        icon.paint(matrices, x + 1, y + 1, iconSize);
     }
 
     @Override
     public void setSize(int x, int y) {
         this.width = 13;
         this.height = 13;
+    }
+
+    @Override
+    public void addTooltip(TooltipBuilder tooltip) {
+        if (this.getLabel() == null) return;
+        tooltip.add(this.getLabel());
     }
 
 }

--- a/src/main/java/net/levelz/init/CommandInit.java
+++ b/src/main/java/net/levelz/init/CommandInit.java
@@ -3,6 +3,7 @@ package net.levelz.init;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.levelz.access.PlayerStatsManagerAccess;
+import net.levelz.config.LevelRule;
 import net.levelz.network.PlayerStatsServerPacket;
 import net.levelz.stats.PlayerStatsManager;
 import net.minecraft.command.argument.EntityArgumentType;
@@ -68,6 +69,9 @@ public class CommandInit {
                         return executeSkillCommand(commandContext.getSource(), EntityArgumentType.getPlayers(commandContext, "targets"), "progress",
                                 IntegerArgumentType.getInteger(commandContext, "level"));
                     })))));
+        });
+        CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
+            dispatcher.register(LevelRule.commandBuilder("levelz", 3));
         });
     }
 

--- a/src/main/java/net/levelz/init/LevelZComponent.java
+++ b/src/main/java/net/levelz/init/LevelZComponent.java
@@ -1,0 +1,22 @@
+package net.levelz.init;
+
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
+import dev.onyxstudios.cca.api.v3.scoreboard.ScoreboardComponentFactoryRegistry;
+import dev.onyxstudios.cca.api.v3.scoreboard.ScoreboardComponentInitializer;
+import net.levelz.config.LevelRule;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.util.Identifier;
+
+public class LevelZComponent implements ScoreboardComponentInitializer {
+    private static final ComponentKey<LevelRule> LEVEL_RULE = ComponentRegistry.getOrCreate(new Identifier("levelz", "rule"), LevelRule.class);
+
+    @Override
+    public void registerScoreboardComponentFactories(ScoreboardComponentFactoryRegistry registry) {
+        registry.registerScoreboardComponent(LEVEL_RULE, (scoreboard, server) -> new LevelRule());
+    }
+
+    public static LevelRule getLevelRule(Scoreboard scoreboard) {
+        return LEVEL_RULE.get(scoreboard);
+    }
+}

--- a/src/main/java/net/levelz/mixin/player/PlayerEntityMixin.java
+++ b/src/main/java/net/levelz/mixin/player/PlayerEntityMixin.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 
+import net.levelz.config.LevelRule;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -21,7 +22,6 @@ import net.levelz.access.PlayerStatsManagerAccess;
 import net.levelz.data.LevelLists;
 import net.levelz.init.ConfigInit;
 import net.levelz.stats.PlayerStatsManager;
-import net.levelz.network.PlayerStatsServerPacket;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.entity.LivingEntity;
@@ -31,13 +31,10 @@ import net.minecraft.entity.player.HungerManager;
 import net.minecraft.item.FoodComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolItem;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.server.network.ServerPlayerEntity;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin extends LivingEntity implements PlayerStatsManagerAccess, PlayerDropAccess {
@@ -67,7 +64,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerSt
 
     @Inject(method = "addExperience", at = @At(value = "TAIL"))
     public void addExperienceMixin(int experience, CallbackInfo info) {
-        if (ConfigInit.CONFIG.useVanillaExp) return;
+        if (LevelRule.getInstance().useVanillaExp()) return;
         playerStatsManager.levelUp(playerEntity, experience);
         /*
         boolean isEndLvl = this.playerStatsManager.isMaxLevel();

--- a/src/main/java/net/levelz/mixin/player/PlayerEntityMixin.java
+++ b/src/main/java/net/levelz/mixin/player/PlayerEntityMixin.java
@@ -67,6 +67,9 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerSt
 
     @Inject(method = "addExperience", at = @At(value = "TAIL"))
     public void addExperienceMixin(int experience, CallbackInfo info) {
+        if (ConfigInit.CONFIG.useVanillaExp) return;
+        playerStatsManager.levelUp(playerEntity, experience);
+        /*
         boolean isEndLvl = this.playerStatsManager.isMaxLevel();
         if (!isEndLvl) {
             playerStatsManager.levelProgress += (float) experience / (float) playerStatsManager.getNextLevelExperience();
@@ -86,6 +89,7 @@ public abstract class PlayerEntityMixin extends LivingEntity implements PlayerSt
                 }
             }
         }
+        */
     }
 
     @Redirect(method = "addExhaustion", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/HungerManager;addExhaustion(F)V"), require = 0)

--- a/src/main/java/net/levelz/mixin/server/MinecraftServerMixin.java
+++ b/src/main/java/net/levelz/mixin/server/MinecraftServerMixin.java
@@ -1,0 +1,21 @@
+package net.levelz.mixin.server;
+
+import net.levelz.config.LevelRule;
+import net.minecraft.scoreboard.ServerScoreboard;
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public abstract class MinecraftServerMixin {
+
+    @Shadow public abstract ServerScoreboard getScoreboard();
+
+    @Inject(method = "loadWorld", at = @At(value = "TAIL"))
+    private void loadWorld(CallbackInfo ci) {
+        LevelRule.registry(this.getScoreboard());
+    }
+}

--- a/src/main/java/net/levelz/network/PlayerStatsClientPacket.java
+++ b/src/main/java/net/levelz/network/PlayerStatsClientPacket.java
@@ -1,8 +1,5 @@
 package net.levelz.network;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.levelz.access.PlayerStatsManagerAccess;
@@ -16,6 +13,9 @@ import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PlayerStatsClientPacket {
 
@@ -107,6 +107,15 @@ public class PlayerStatsClientPacket {
                 }
             }
         });
+
+        ClientPlayNetworking.registerGlobalReceiver(PlayerStatsServerPacket.ADD_EXPERIENCE_PACKET, (client, handler, buf, sender) -> {
+            PlayerEntity player = client.player;
+            if (player == null) return;
+            int experience = buf.readInt();
+            client.execute(() -> {
+                player.addExperience(experience);
+            });
+        });
     }
 
     public static void writeC2SIncreaseLevelPacket(PlayerStatsManager playerStatsManager, String string) {
@@ -117,6 +126,13 @@ public class PlayerStatsClientPacket {
         buf.writeInt(playerStatsManager.getLevel(string));
 
         CustomPayloadC2SPacket packet = new CustomPayloadC2SPacket(PlayerStatsServerPacket.STATS_INCREASE_PACKET, buf);
+        MinecraftClient.getInstance().getNetworkHandler().sendPacket(packet);
+    }
+
+    public static void writeC2SLevelUpPacket() {
+        // Levelz level up
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        CustomPayloadC2SPacket packet = new CustomPayloadC2SPacket(PlayerStatsServerPacket.LEVEL_UP_PACKET, buf);
         MinecraftClient.getInstance().getNetworkHandler().sendPacket(packet);
     }
 

--- a/src/main/java/net/levelz/network/PlayerStatsServerPacket.java
+++ b/src/main/java/net/levelz/network/PlayerStatsServerPacket.java
@@ -1,7 +1,5 @@
 package net.levelz.network;
 
-import java.util.ArrayList;
-
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.levelz.access.PlayerStatsManagerAccess;
@@ -14,6 +12,8 @@ import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
+import java.util.ArrayList;
+
 public class PlayerStatsServerPacket {
 
     public static final Identifier STATS_INCREASE_PACKET = new Identifier("levelz", "player_increase_stats");
@@ -22,6 +22,8 @@ public class PlayerStatsServerPacket {
     public static final Identifier LIST_PACKET = new Identifier("levelz", "unlocking_list");
     public static final Identifier STRENGTH_PACKET = new Identifier("levelz", "strength_sync");
     public static final Identifier RESET_PACKET = new Identifier("levelz", "reset_skill");
+    public static final Identifier ADD_EXPERIENCE_PACKET = new Identifier("levelz", "add_experience");
+    public static final Identifier LEVEL_UP_PACKET = new Identifier("levelz", "level_up");
 
     public static void init() {
         ServerPlayNetworking.registerGlobalReceiver(STATS_INCREASE_PACKET, (server, player, handler, buffer, sender) -> {
@@ -49,6 +51,12 @@ public class PlayerStatsServerPacket {
                     syncLockedBrewingItemList(playerStatsManager);
                 }
             }
+        });
+
+        ServerPlayNetworking.registerGlobalReceiver(LEVEL_UP_PACKET, (server, player, handler, buffer, sender) -> {
+            if (player == null) return;
+            PlayerStatsManager playerStatsManager = ((PlayerStatsManagerAccess) player).getPlayerStatsManager(player);
+            playerStatsManager.levelUp(player, 0);
         });
 
     }
@@ -172,6 +180,15 @@ public class PlayerStatsServerPacket {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         buf.writeString(skill);
         CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(RESET_PACKET, buf);
+        serverPlayerEntity.networkHandler.sendPacket(packet);
+    }
+
+    public static void writeS2CAddExperiencePacket(ServerPlayerEntity serverPlayerEntity, int experience) {
+        // Add player experience
+        // serverPlayerEntity.addExperience(experience);
+        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+        buf.writeInt(experience);
+        CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(ADD_EXPERIENCE_PACKET, buf);
         serverPlayerEntity.networkHandler.sendPacket(packet);
     }
 

--- a/src/main/java/net/levelz/stats/PlayerStatsManager.java
+++ b/src/main/java/net/levelz/stats/PlayerStatsManager.java
@@ -1,9 +1,5 @@
 package net.levelz.stats;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
 import net.levelz.access.PlayerStatsManagerAccess;
 import net.levelz.data.LevelLists;
 import net.levelz.init.ConfigInit;
@@ -11,9 +7,15 @@ import net.levelz.network.PlayerStatsServerPacket;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.MathHelper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 public class PlayerStatsManager {
+
     // Level
     public int overallLevel;
     public float levelProgress;
@@ -86,85 +88,85 @@ public class PlayerStatsManager {
 
     public void setLevel(String string, int level) {
         switch (string) {
-        case "level":
-            this.overallLevel = level;
-            break;
-        case "health":
-            this.healthLevel = level;
-            break;
-        case "strength":
-            this.strengthLevel = level;
-            break;
-        case "agility":
-            this.agilityLevel = level;
-            break;
-        case "defense":
-            this.defenseLevel = level;
-            break;
-        case "stamina":
-            this.staminaLevel = level;
-            break;
-        case "luck":
-            this.luckLevel = level;
-            break;
-        case "archery":
-            this.archeryLevel = level;
-            break;
-        case "trade":
-            this.tradeLevel = level;
-            break;
-        case "smithing":
-            this.smithingLevel = level;
-            break;
-        case "mining":
-            this.miningLevel = level;
-            break;
-        case "farming":
-            this.farmingLevel = level;
-            break;
-        case "alchemy":
-            this.alchemyLevel = level;
-            break;
-        case "points":
-            this.skillPoints = level;
-            break;
-        default:
-            break;
+            case "level":
+                this.overallLevel = level;
+                break;
+            case "health":
+                this.healthLevel = level;
+                break;
+            case "strength":
+                this.strengthLevel = level;
+                break;
+            case "agility":
+                this.agilityLevel = level;
+                break;
+            case "defense":
+                this.defenseLevel = level;
+                break;
+            case "stamina":
+                this.staminaLevel = level;
+                break;
+            case "luck":
+                this.luckLevel = level;
+                break;
+            case "archery":
+                this.archeryLevel = level;
+                break;
+            case "trade":
+                this.tradeLevel = level;
+                break;
+            case "smithing":
+                this.smithingLevel = level;
+                break;
+            case "mining":
+                this.miningLevel = level;
+                break;
+            case "farming":
+                this.farmingLevel = level;
+                break;
+            case "alchemy":
+                this.alchemyLevel = level;
+                break;
+            case "points":
+                this.skillPoints = level;
+                break;
+            default:
+                break;
         }
     }
 
     public int getLevel(String string) {
         switch (string) {
-        case "level":
-            return this.overallLevel;
-        case "health":
-            return this.healthLevel;
-        case "strength":
-            return this.strengthLevel;
-        case "agility":
-            return this.agilityLevel;
-        case "defense":
-            return this.defenseLevel;
-        case "stamina":
-            return this.staminaLevel;
-        case "luck":
-            return this.luckLevel;
-        case "archery":
-            return this.archeryLevel;
-        case "trade":
-            return this.tradeLevel;
-        case "smithing":
-            return this.smithingLevel;
-        case "mining":
-            return this.miningLevel;
-        case "farming":
-            return this.farmingLevel;
-        case "alchemy":
-            return this.alchemyLevel;
-        case "points":
-            return this.skillPoints;
-        default:
-            return 0;
+            case "level":
+                return this.overallLevel;
+            case "health":
+                return this.healthLevel;
+            case "strength":
+                return this.strengthLevel;
+            case "agility":
+                return this.agilityLevel;
+            case "defense":
+                return this.defenseLevel;
+            case "stamina":
+                return this.staminaLevel;
+            case "luck":
+                return this.luckLevel;
+            case "archery":
+                return this.archeryLevel;
+            case "trade":
+                return this.tradeLevel;
+            case "smithing":
+                return this.smithingLevel;
+            case "mining":
+                return this.miningLevel;
+            case "farming":
+                return this.farmingLevel;
+            case "alchemy":
+                return this.alchemyLevel;
+            case "points":
+                return this.skillPoints;
+            default:
+                return 0;
         }
     }
 
@@ -176,6 +178,27 @@ public class PlayerStatsManager {
             this.levelProgress = 0.0F;
             this.totalLevelExperience = 0;
         }
+    }
+
+    public float getLevelProgress(PlayerEntity playerEntity) {
+        if (ConfigInit.CONFIG.useVanillaExp) {
+            return Math.min(getPlayerExp(playerEntity) / (float) this.getNextLevelExperience(), 1F);
+        }
+        return levelProgress;
+    }
+
+    public static int getPlayerExp(PlayerEntity playerEntity) {
+        int level = playerEntity.experienceLevel;
+        int exp = 0;
+        for (int i = 0; i < level; i++) {
+            if (i >= 30) {
+                exp += 112 + (i - 30) * 9;
+            } else {
+                exp += i >= 15 ? 37 + (i - 15) * 5 : 7 + i * 2;
+            }
+        }
+        exp += playerEntity.getNextLevelExperience() * playerEntity.experienceProgress;
+        return exp;
     }
 
     public boolean isMaxLevel() {
@@ -287,34 +310,49 @@ public class PlayerStatsManager {
     }
 
     public static String getRandomSkillString(Random random) {
-        switch (random.nextInt(12)) {
-        case 0:
-            return "health";
-        case 1:
-            return "strength";
-        case 2:
-            return "agility";
-        case 3:
-            return "defense";
-        case 4:
-            return "stamina";
-        case 5:
-            return "luck";
-        case 6:
-            return "archery";
-        case 7:
-            return "trade";
-        case 8:
-            return "smithing";
-        case 9:
-            return "farming";
-        case 10:
-            return "alchemy";
-        case 11:
-            return "mining";
-        default:
-            return "health";
+        return switch (random.nextInt(12)) {
+            case 0 -> "health";
+            case 1 -> "strength";
+            case 2 -> "agility";
+            case 3 -> "defense";
+            case 4 -> "stamina";
+            case 5 -> "luck";
+            case 6 -> "archery";
+            case 7 -> "trade";
+            case 8 -> "smithing";
+            case 9 -> "farming";
+            case 10 -> "alchemy";
+            case 11 -> "mining";
+            default -> "health";
+        };
+    }
+
+    public void levelUp(PlayerEntity playerEntity, int experience) {
+        if (this.isMaxLevel()) return;
+        if (ConfigInit.CONFIG.useVanillaExp) {
+            if (this.getLevelProgress(playerEntity) < 1) return;
+            experience = this.getNextLevelExperience();
+        } else {
+            experience += this.levelProgress * this.getNextLevelExperience();
         }
+        this.totalLevelExperience = MathHelper.clamp(this.totalLevelExperience + experience, 0, Integer.MAX_VALUE);
+        while (experience >= this.getNextLevelExperience() && !this.isMaxLevel()) {
+            this.addExperienceLevels(1);
+            if (ConfigInit.CONFIG.useVanillaExp) playerEntity.addExperience(-experience);
+            if (playerEntity instanceof ServerPlayerEntity) {
+                PlayerStatsServerPacket.writeS2CSkillPacket(this, (ServerPlayerEntity) playerEntity);
+                if (ConfigInit.CONFIG.useVanillaExp)
+                    PlayerStatsServerPacket.writeS2CAddExperiencePacket((ServerPlayerEntity) playerEntity, -experience);
+                onLevelUp(playerEntity, this.overallLevel);
+            }
+            if (this.overallLevel > 0 && this.overallLevel % 10 == 0) {
+                float f = this.overallLevel > 30 ? 1.0F : (float) this.overallLevel / 30.0F;
+                playerEntity.world.playSound(null, playerEntity.getX(), playerEntity.getY(), playerEntity.getZ(), SoundEvents.ENTITY_PLAYER_LEVELUP, playerEntity.getSoundCategory(), f * 0.75F,
+                        1.0F);
+            }
+            experience -= this.getNextLevelExperience();
+        }
+        this.levelProgress = Math.max((float) experience / this.getNextLevelExperience(), 0);
     }
 
     // Called on server only

--- a/src/main/java/net/levelz/stats/PlayerStatsManager.java
+++ b/src/main/java/net/levelz/stats/PlayerStatsManager.java
@@ -214,6 +214,7 @@ public class PlayerStatsManager {
     }
 
     public static boolean playerLevelisHighEnough(PlayerEntity playerEntity, List<Object> list, String string, boolean creativeRequired) {
+        if (list== null || list.isEmpty()) return true;
         if (!playerEntity.isCreative() || !creativeRequired) {
             PlayerStatsManager playerStatsManager = ((PlayerStatsManagerAccess) playerEntity).getPlayerStatsManager(playerEntity);
             int playerLevel = 0;

--- a/src/main/java/net/levelz/stats/PlayerStatsManager.java
+++ b/src/main/java/net/levelz/stats/PlayerStatsManager.java
@@ -1,6 +1,7 @@
 package net.levelz.stats;
 
 import net.levelz.access.PlayerStatsManagerAccess;
+import net.levelz.config.LevelRule;
 import net.levelz.data.LevelLists;
 import net.levelz.init.ConfigInit;
 import net.levelz.network.PlayerStatsServerPacket;
@@ -181,7 +182,7 @@ public class PlayerStatsManager {
     }
 
     public float getLevelProgress(PlayerEntity playerEntity) {
-        if (ConfigInit.CONFIG.useVanillaExp) {
+        if (LevelRule.getInstance().useVanillaExp()) {
             return Math.min(getPlayerExp(playerEntity) / (float) this.getNextLevelExperience(), 1F);
         }
         return levelProgress;
@@ -330,7 +331,7 @@ public class PlayerStatsManager {
 
     public void levelUp(PlayerEntity playerEntity, int experience) {
         if (this.isMaxLevel()) return;
-        if (ConfigInit.CONFIG.useVanillaExp) {
+        if (LevelRule.getInstance().useVanillaExp()) {
             if (this.getLevelProgress(playerEntity) < 1) return;
             experience = this.getNextLevelExperience();
         } else {
@@ -339,10 +340,10 @@ public class PlayerStatsManager {
         this.totalLevelExperience = MathHelper.clamp(this.totalLevelExperience + experience, 0, Integer.MAX_VALUE);
         while (experience >= this.getNextLevelExperience() && !this.isMaxLevel()) {
             this.addExperienceLevels(1);
-            if (ConfigInit.CONFIG.useVanillaExp) playerEntity.addExperience(-experience);
+            if (LevelRule.getInstance().useVanillaExp()) playerEntity.addExperience(-experience);
             if (playerEntity instanceof ServerPlayerEntity) {
                 PlayerStatsServerPacket.writeS2CSkillPacket(this, (ServerPlayerEntity) playerEntity);
-                if (ConfigInit.CONFIG.useVanillaExp)
+                if (LevelRule.getInstance().useVanillaExp())
                     PlayerStatsServerPacket.writeS2CAddExperiencePacket((ServerPlayerEntity) playerEntity, -experience);
                 onLevelUp(playerEntity, this.overallLevel);
             }

--- a/src/main/resources/assets/levelz/lang/en_us.json
+++ b/src/main/resources/assets/levelz/lang/en_us.json
@@ -7,6 +7,8 @@
   "text.autoconfig.levelz.title": "LevelZ Config",
   "text.autoconfig.levelz.category.level_setting": "Level Settings",
   "text.autoconfig.levelz.category.default": "Skill Settings",
+  "text.autoconfig.levelz.option.useVanillaExp": "Use Vanilla Exp",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip": "Use the original experience to increase the skill level",
   "text.autoconfig.levelz.option.hardMode": "Hard Mode",
   "text.autoconfig.levelz.option.disableMobFarms": "Disable Mob Farms",
   "text.autoconfig.levelz.option.maxLevel": "Max Level",
@@ -58,7 +60,7 @@
   "text.autoconfig.levelz.option.dropPlayerXP": "Drop Player XP",
 
   "item.levelz.strange_potion": "Strange Potion",
-  
+
   "item.levelz.locked.tooltip": "Locked",
   "item.levelz.farming.tooltip": "Farming %d",
   "item.levelz.mining.tooltip": "Mining %d",
@@ -82,6 +84,7 @@
   "text.levelz.gui.title": "%s Skills",
   "text.levelz.gui.level": "Level %d",
   "text.levelz.gui.points": "Points %d",
+  "text.levelz.gui.level_up": "Level up",
 
   "text.levelz.level": "Level %d",
   "text.levelz.locked_list": "%s list",

--- a/src/main/resources/assets/levelz/lang/en_us.json
+++ b/src/main/resources/assets/levelz/lang/en_us.json
@@ -8,7 +8,9 @@
   "text.autoconfig.levelz.category.level_setting": "Level Settings",
   "text.autoconfig.levelz.category.default": "Skill Settings",
   "text.autoconfig.levelz.option.useVanillaExp": "Use Vanilla Exp",
-  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip": "Use the original experience to increase the skill level",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[0]": "Use the original experience to increase the skill level",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[1]": "Only effective when the archive is created",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[2]": "Please use the command \"/levelz useVanillaExp [true|false]\" to modify in the game",
   "text.autoconfig.levelz.option.hardMode": "Hard Mode",
   "text.autoconfig.levelz.option.disableMobFarms": "Disable Mob Farms",
   "text.autoconfig.levelz.option.maxLevel": "Max Level",
@@ -242,5 +244,9 @@
 
   "config.waila.plugin_levelz": "LevelZ",
   "config.waila.plugin_levelz.mineable_info": "Mineable Info",
-  "config.waila.plugin_levelz.mineable_level_info": "Mineable Level Info"
+  "config.waila.plugin_levelz.mineable_level_info": "Mineable Level Info",
+
+  "commands.levelz.rule.changed": "Level rule got changed",
+  "commands.levelz.rule.error": "Command execution encountered an error",
+  "commands.levelz.rule.notfound": "rule not found"
 }

--- a/src/main/resources/assets/levelz/lang/zh_cn.json
+++ b/src/main/resources/assets/levelz/lang/zh_cn.json
@@ -8,7 +8,9 @@
   "text.autoconfig.levelz.category.level_setting": "等级设置",
   "text.autoconfig.levelz.category.default": "技能设置",
   "text.autoconfig.levelz.option.useVanillaExp": "使用原版经验",
-  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip": "使用原版经验提升技能等级",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[0]": "使用原版经验提升技能等级",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[1]": "仅在创建存档时生效",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip[2]": "游戏中修改请使用命令 \"/levelz useVanillaExp [true|false]\"",
   "text.autoconfig.levelz.option.hardMode": "极限模式 (开启后玩家死亡时清除所有点数和经验)",
   "text.autoconfig.levelz.option.disableMobFarms": "禁用刷怪塔",
   "text.autoconfig.levelz.option.maxLevel": "最大等级",
@@ -242,5 +244,9 @@
 
   "config.waila.plugin_levelz": "LevelZ",
   "config.waila.plugin_levelz.mineable_info": "可挖掘状态显示",
-  "config.waila.plugin_levelz.mineable_level_info": "可挖掘等级显示"
+  "config.waila.plugin_levelz.mineable_level_info": "可挖掘等级显示",
+
+  "commands.levelz.rule.changed": "存档规则已更新",
+  "commands.levelz.rule.error": "值错误/其他错误",
+  "commands.levelz.rule.notfound": "不存在的存档规则，请检查命令"
 }

--- a/src/main/resources/assets/levelz/lang/zh_cn.json
+++ b/src/main/resources/assets/levelz/lang/zh_cn.json
@@ -7,6 +7,8 @@
   "text.autoconfig.levelz.title": "LevelZ 配置",
   "text.autoconfig.levelz.category.level_setting": "等级设置",
   "text.autoconfig.levelz.category.default": "技能设置",
+  "text.autoconfig.levelz.option.useVanillaExp": "使用原版经验",
+  "text.autoconfig.levelz.option.useVanillaExp.@Tooltip": "使用原版经验提升技能等级",
   "text.autoconfig.levelz.option.hardMode": "极限模式 (开启后玩家死亡时清除所有点数和经验)",
   "text.autoconfig.levelz.option.disableMobFarms": "禁用刷怪塔",
   "text.autoconfig.levelz.option.maxLevel": "最大等级",
@@ -82,6 +84,7 @@
   "text.levelz.gui.title": "%s 技能面板",
   "text.levelz.gui.level": "等级 %d",
   "text.levelz.gui.points": "技能点 %d",
+  "text.levelz.gui.level_up": "升级",
 
   "text.levelz.level": "Lv.%d",
   "text.levelz.locked_list": "%s列表",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,9 @@
     ],
     "modmenu": [
       "net.levelz.config.ModMenuIntegration"
+    ],
+    "cardinal-components-scoreboard": [
+      "net.levelz.init.LevelZComponent"
     ]
   },
   "mixins": [
@@ -43,6 +46,9 @@
     "waila:plugins": {
       "id": "levelz:plugin",
       "initializer": "net.levelz.waila.LevelWailaPlugin"
-    }
+    },
+    "cardinal-components": [
+      "levelz:rule"
+    ]
   }
 }

--- a/src/main/resources/levelz.mixins.json
+++ b/src/main/resources/levelz.mixins.json
@@ -69,7 +69,8 @@
     "misc.ServerWorldMixin",
     "misc.LootableContainerBlockEntityMixin",
     "misc.PotionSlotMixin",
-    "misc.ExperienceOrbEntityMixin"
+    "misc.ExperienceOrbEntityMixin",
+    "server.MinecraftServerMixin"
   ],
   "client": [
     "player.ClientPlayerEntityMixin",


### PR DESCRIPTION
> Sorry for my english.

This PR contains #73.

**Use vanilla exp**
/xp add Player 456
![2021-12-19_20 58 24](https://user-images.githubusercontent.com/19365612/146676043-ea74aaa0-62a9-44c1-965f-04005875c542.png)
There is an LevelUp button. (one level each time)
![2021-12-19_20 59 22](https://user-images.githubusercontent.com/19365612/146676052-60362e0e-8dec-4c2e-be44-dcaa81438643.png)
![2021-12-19_20 59 55](https://user-images.githubusercontent.com/19365612/146676059-2de047ed-760d-4c6f-890d-a8ee1ac5dc67.png)
**Switchable**
![2021-12-19_21 01 07](https://user-images.githubusercontent.com/19365612/146676076-d7eb9182-71c7-4e56-b94c-ca30c78e66a3.png)
**Use extra experience**
![2021-12-19_21 01 44](https://user-images.githubusercontent.com/19365612/146676088-f55d1523-f551-428e-82b3-7067e0c8a5eb.png)
/xp add Player 500
![2021-12-19_21 04 03](https://user-images.githubusercontent.com/19365612/146676096-57cbff77-0bd4-4620-91f1-e23b14478b0e.png)
Switching back to vanilla experience will result in an extra portion of usable experience. But there seems to be no effective solution, 
![2021-12-19_21 05 56](https://user-images.githubusercontent.com/19365612/146676101-88c62798-f2f8-447f-b6aa-5a084a7d4da5.png)
