### PR TITLE
fixed resetCurrentXp being overridden on respawn causing xp duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 - 
 ### Fixed:
 - Fixed emi error log
+- Fixed resetCurrentXp being overridden by skill state copy on respawn causing xp duplication
 ### Changed:
 - Tweaked AdditionZ fishing experience compat

--- a/src/main/java/net/levelz/init/EventInit.java
+++ b/src/main/java/net/levelz/init/EventInit.java
@@ -51,11 +51,6 @@ public class EventInit {
         ServerPlayerEvents.AFTER_RESPAWN.register((oldPlayer, newPlayer, alive) -> {
             LevelManager newLevelManager = ((LevelManagerAccess) newPlayer).getLevelManager();
 
-            if (ConfigInit.CONFIG.resetCurrentXp) {
-                newLevelManager.setLevelProgress(0);
-                newLevelManager.setTotalLevelExperience(0);
-            }
-
             if (ConfigInit.CONFIG.levelRetainPercentage < 100) {
                 LevelManager oldLevelManager = ((LevelManagerAccess) oldPlayer).getLevelManager();
                 float levelRetainPercentageFloat = ConfigInit.CONFIG.levelRetainPercentage / 100;
@@ -102,6 +97,11 @@ public class EventInit {
                 newPlayer.getServer().getPlayerManager().sendToAll(new PlayerListS2CPacket(PlayerListS2CPacket.Action.UPDATE_GAME_MODE, newPlayer));
             } else {
                 PacketHelper.updatePlayerSkills(newPlayer, oldPlayer);
+
+                if (ConfigInit.CONFIG.resetCurrentXp) {
+                    newLevelManager.setLevelProgress(0);
+                    newLevelManager.setTotalLevelExperience(0);
+                }
 
                 PacketHelper.updateLevels(newPlayer);
                 for (Skill skill : LevelManager.SKILLS.values()) {


### PR DESCRIPTION
Hey! First off, thanks for maintaining LevelZ — it's been a lot of fun to play with. I ran into a bug and wanted to contribute a fix!

## Summary
- Fixed a bug where `resetCurrentXp=true` with `levelRetainPercentage=100` (default) caused XP duplication on death

## Root Cause
In the `AFTER_RESPAWN` handler, the reset block ran before `updatePlayerSkills(newPlayer, oldPlayer)`, which internally calls `setLevelProgress(oldLevelManager.getLevelProgress())` and overwrites the reset. As a result, the player dropped a `LevelExperienceOrbEntity` but kept their full progress — pure XP duplication.

## Fix
Moved the `resetCurrentXp` reset block inside the `else` branch, after `updatePlayerSkills`, so the reset is applied after the state copy and cannot be overwritten.